### PR TITLE
Implement mode of operation

### DIFF
--- a/readyset_proxysql_scheduler.cnf
+++ b/readyset_proxysql_scheduler.cnf
@@ -10,3 +10,4 @@ source_hostgroup = 11
 readyset_hostgroup = 99
 warmup_time = 60
 lock_file = '/tmp/readyset_scheduler.lock'
+operation_mode=all

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,37 @@
-use std::{fs::File, io::Read};
+use std::{
+    fmt::{Display, Formatter},
+    fs::File,
+    io::Read,
+};
+
+#[derive(serde::Deserialize, Clone, Copy, PartialEq, PartialOrd, Default)]
+pub enum OperationMode {
+    HealthCheck,
+    QueryDiscovery,
+    #[default]
+    All,
+}
+
+impl From<String> for OperationMode {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "health_check" => OperationMode::HealthCheck,
+            "query_discovery" => OperationMode::QueryDiscovery,
+            "all" => OperationMode::All,
+            _ => OperationMode::All,
+        }
+    }
+}
+
+impl Display for OperationMode {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            OperationMode::HealthCheck => write!(f, "health_check"),
+            OperationMode::QueryDiscovery => write!(f, "query_discovery"),
+            OperationMode::All => write!(f, "all"),
+        }
+    }
+}
 
 #[derive(serde::Deserialize, Clone)]
 pub struct Config {
@@ -14,6 +47,7 @@ pub struct Config {
     pub readyset_hostgroup: u16,
     pub warmup_time: Option<u16>,
     pub lock_file: Option<String>,
+    pub operation_mode: Option<OperationMode>,
 }
 
 pub fn read_config_file(path: &str) -> Result<String, std::io::Error> {

--- a/src/health_check.rs
+++ b/src/health_check.rs
@@ -1,0 +1,27 @@
+use crate::{
+    config, messages,
+    server::{self, ServerStatus},
+};
+
+pub fn health_check(
+    proxysql_conn: &mut mysql::PooledConn,
+    config: &config::Config,
+    readyset_conn: &mut mysql::PooledConn,
+) {
+    match server::check_readyset_is_ready(readyset_conn) {
+        Ok(ready) => {
+            if ready {
+                let _ = server::change_server_status(proxysql_conn, config, ServerStatus::Online);
+            } else {
+                messages::print_info("Readyset is still running Snapshot.");
+                let _ = server::change_server_status(proxysql_conn, config, ServerStatus::Shunned);
+                std::process::exit(0);
+            }
+        }
+        Err(e) => {
+            messages::print_error(format!("Cannot check Readyset status: {}.", e).as_str());
+            let _ = server::change_server_status(proxysql_conn, config, ServerStatus::Shunned);
+            std::process::exit(1);
+        }
+    };
+}


### PR DESCRIPTION
This commits implement mode of operation, allowing users to instruct scheduler to operate in health check mode, query discovery mode or both.

Closes #9