### PR TITLE
Limit number of caches

### DIFF
--- a/readyset_proxysql_scheduler.cnf
+++ b/readyset_proxysql_scheduler.cnf
@@ -10,4 +10,5 @@ source_hostgroup = 11
 readyset_hostgroup = 99
 warmup_time = 60
 lock_file = '/tmp/readyset_scheduler.lock'
-operation_mode=all
+operation_mode="All"
+number_of_queries=10

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub warmup_time: Option<u16>,
     pub lock_file: Option<String>,
     pub operation_mode: Option<OperationMode>,
+    pub number_of_queries: u16,
 }
 
 pub fn read_config_file(path: &str) -> Result<String, std::io::Error> {


### PR DESCRIPTION
This commit adds a configuration to limit the number of caches the tool will create.

The default value is 10.

Fixes #4