### PR TITLE
Add build from docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.vscode/

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+services:
+  proxysql:
+    image: proxysql/proxysql
+    ports:
+      - "6033:6033"
+      - "6032:6032"
+    volumes:
+      - ./proxysql.cnf:/etc/proxysql.cnf
+  mysql-master:
+    image: mysql:8.0
+    container_name: mysql-master
+    environment:
+      - MYSQL_ROOT_PASSWORD=noria
+      - MYSQL_DATABASE=noria
+    command: --server-id=1 
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -u root -pnoria"]
+      interval: 10s
+      retries: 20
+      start_period: 30s
+      timeout: 10s
+  readyset:
+    image: readysettech/readyset
+    ports:
+      - "3307:3307"
+      - "6034:6034"
+    environment:
+      - UPSTREAM_DB_URL=mysql://root:noria@172.17.0.1:3306/noria
+    depends_on:
+      mysql-master:
+        condition: service_healthy
+        restart: true
+

--- a/build/proxysql.cnf
+++ b/build/proxysql.cnf
@@ -1,0 +1,30 @@
+admin_variables=
+{
+	admin_credentials="admin:admin;radmin:radmin"
+}
+
+# defines all the MySQL servers
+mysql_servers =
+(
+	{ address="host.docker.internal" , port=3306 , hostgroup=1, comment="Source" },
+	{ address="host.docker.internal" , port=3307 , hostgroup=2, weight=1000, comment="Readyset" },
+	{ address="host.docker.internal" , port=3306 , hostgroup=2, weight=1, comment="Source" }
+)
+
+mysql_variables=
+{
+	monitor_username="root"
+	monitor_password="noria"
+}
+
+mysql_users:
+(
+	{
+		username = "root"
+		password = "noria"
+		default_hostgroup = 1
+		max_connections=1000
+		default_schema="noria"
+		active = 1
+	}
+)


### PR DESCRIPTION
This commit adds a minimal build of a proxysql, mysql and readyset via docker compose file. With this we can start a local environment to test the scheduler.