### PR TITLE
Filter out hosts that are OFFLINE_SOFT or OFFLINE_HARD

### DIFF
--- a/src/proxysql.rs
+++ b/src/proxysql.rs
@@ -39,7 +39,7 @@ impl ProxySQL {
         .expect("Failed to create ProxySQL connection");
 
         let query = format!(
-            "SELECT hostname, port, status, comment FROM mysql_servers WHERE hostgroup_id = {}",
+            "SELECT hostname, port, status, comment FROM mysql_servers WHERE hostgroup_id = {} AND status IN ('ONLINE', 'SHUNNED')",
             config.readyset_hostgroup
         );
         let results: Vec<(String, u16, String, String)> = conn.query(query).unwrap();


### PR DESCRIPTION
If a user wants to gracefully remove a host from proxysql, it will change the status to OFFLINE_SOFT, wait it to complete all the current ongoing connections and then change it to OFFLINE_HARD. The scheduler should not consider those hosts as available to be used and filter them out.

Fixes: #25