### PR TITLE
Add dry-run option to the CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ struct Args {
     /// path to the config file
     #[arg(long)]
     config: String,
+    /// Dry run mode
+    #[arg(long)]
+    dry_run: bool,
 }
 
 fn main() {
@@ -61,7 +64,7 @@ fn main() {
         }
     };
 
-    let mut proxysql = ProxySQL::new(&config);
+    let mut proxysql = ProxySQL::new(&config, args.dry_run);
 
     let running_mode = match config.operation_mode {
         Some(mode) => mode,

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -193,13 +193,17 @@ impl QueryDiscovery {
                                 .as_str(),
                         );
                         queries_added_or_change = true;
-                        proxysql.get_online_hosts().iter_mut().for_each(|host| {
-                            host.cache_query(query)
-                                .expect("Failed to create readyset cache");
-                        });
-                        proxysql
-                            .add_as_query_rule(query)
-                            .expect("Failed to add query rule");
+                        if !proxysql.dry_run() {
+                            proxysql.get_online_hosts().iter_mut().for_each(|host| {
+                                host.cache_query(query)
+                                    .expect("Failed to create readyset cache");
+                            });
+                            proxysql
+                                .add_as_query_rule(query)
+                                .expect("Failed to add query rule");
+                        } else {
+                            messages::print_info("Dry run, not adding query");
+                        }
                         current_queries_digest.push(query.get_digest().to_string());
                     }
                     Ok(false) => {


### PR DESCRIPTION
This commit adds a new mode of operation to the CLI, the dry-run mode. In this mode, the CLI will not execute any changes, but will instead print them to the console.

Closes #28