### PR TITLE
Consolidate config defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,14 @@ pub enum QueryDiscoveryMode {
     External,
 }
 
+fn default_lock_file() -> String {
+    "/tmp/readyset_scheduler.lock".to_string()
+}
+
+fn default_number_of_queries() -> u16 {
+    10
+}
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct Config {
     pub proxysql_user: String,
@@ -61,14 +69,22 @@ pub struct Config {
     pub readyset_password: String,
     pub source_hostgroup: u16,
     pub readyset_hostgroup: u16,
-    pub warmup_time_s: Option<u16>,
-    pub lock_file: Option<String>,
-    pub operation_mode: Option<OperationMode>,
+    #[serde(default)]
+    pub warmup_time_s: u16,
+    #[serde(default = "default_lock_file")]
+    pub lock_file: String,
+    #[serde(default)]
+    pub operation_mode: OperationMode,
+    #[serde(default = "default_number_of_queries")]
     pub number_of_queries: u16,
-    pub query_discovery_mode: Option<QueryDiscoveryMode>,
-    pub query_discovery_min_execution: Option<u64>,
-    pub query_discovery_min_row_sent: Option<u64>,
-    pub log_verbosity: Option<MessageType>,
+    #[serde(default)]
+    pub query_discovery_mode: QueryDiscoveryMode,
+    #[serde(default)]
+    pub query_discovery_min_execution: u64,
+    #[serde(default)]
+    pub query_discovery_min_row_sent: u64,
+    #[serde(default)]
+    pub log_verbosity: MessageType,
 }
 
 pub fn read_config_file(path: &str) -> Result<String, std::io::Error> {

--- a/src/proxysql.rs
+++ b/src/proxysql.rs
@@ -60,7 +60,7 @@ impl ProxySQL {
         ProxySQL {
             conn,
             readyset_hostgroup: config.readyset_hostgroup,
-            warmup_time_s: config.warmup_time_s.unwrap_or(0),
+            warmup_time_s: config.warmup_time_s,
             readysets,
             dry_run,
         }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -96,11 +96,9 @@ impl QueryDiscovery {
     /// A new QueryDiscovery struct.
     pub fn new(config: &Config) -> Self {
         QueryDiscovery {
-            query_discovery_mode: config
-                .query_discovery_mode
-                .unwrap_or(QueryDiscoveryMode::CountStar),
-            query_discovery_min_execution: config.query_discovery_min_execution.unwrap_or(0),
-            query_discovery_min_rows_sent: config.query_discovery_min_row_sent.unwrap_or(0),
+            query_discovery_mode: config.query_discovery_mode,
+            query_discovery_min_execution: config.query_discovery_min_execution,
+            query_discovery_min_rows_sent: config.query_discovery_min_row_sent,
             source_hostgroup: config.source_hostgroup,
             readyset_user: config.readyset_user.clone(),
             number_of_queries: config.number_of_queries,


### PR DESCRIPTION
Use #[serde(default)] to provide default values for missing configuration options during deserialization.  This typically makes use of the type's Default trait, but we also specify a couple default functions for standard types when a custom default is desired.

Also make number_of_queries optional to bring its semantics into alignment with the documentation in the README.md.  I think it was accidentally specified as a required option.