### PR TITLE
Allow configuration for PostgreSQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1283,7 @@ dependencies = [
 name = "readyset_proxysql_scheduler"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "file-guard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0"
 chrono = "0.4.35"
 file-guard = "0.2.0"
 once_cell = "1.10.0"
+anyhow = "1.0.97"
 
 
 [package.metadata.generate-rpm]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ SAVE SCHEDULER TO DISK;
 ```
 
 Configure `/etc/readyset_proxysql_scheduler.cnf` as follow:
+* `database_type` - (Optional) - Either `"mysql"` or `"postgresql"` (Default `"mysql"`)
 * `proxysql_user` - (Required) - ProxySQL admin user
 * `proxysql_password` - (Required) - ProxySQL admin password
 * `proxysql_host` - (Required) - ProxySQL admin host

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,14 @@ use std::{
 
 use crate::messages::MessageType;
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DatabaseType {
+    #[default]
+    MySQL,
+    PostgreSQL,
+}
+
 #[derive(Deserialize, Clone, Copy, PartialEq, PartialOrd, Default, Debug)]
 pub enum OperationMode {
     HealthCheck,
@@ -61,6 +69,8 @@ fn default_number_of_queries() -> u16 {
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct Config {
+    #[serde(default)]
+    pub database_type: DatabaseType,
     pub proxysql_user: String,
     pub proxysql_password: String,
     pub proxysql_host: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod messages;
 mod proxysql;
 mod queries;
 mod readyset;
+mod sql_connection;
 
 use clap::Parser;
 use config::{read_config_file, OperationMode};

--- a/src/sql_connection.rs
+++ b/src/sql_connection.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use mysql::{
+    prelude::{FromRow, Queryable},
+    Conn, OptsBuilder,
+};
+
+use crate::config::DatabaseType;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[allow(dead_code)]
+pub enum SQLConnection {
+    MySQL(Conn),
+    PostgreSQL,
+}
+
+impl SQLConnection {
+    pub fn new(
+        database_type: DatabaseType,
+        hostname: &str,
+        port: u16,
+        user: &str,
+        pass: &str,
+    ) -> Result<Self> {
+        Ok(match database_type {
+            DatabaseType::MySQL => Self::MySQL(Conn::new(
+                OptsBuilder::new()
+                    .ip_or_hostname(Some(hostname))
+                    .tcp_port(port)
+                    .user(Some(user))
+                    .pass(Some(pass))
+                    .prefer_socket(false)
+                    .read_timeout(Some(TIMEOUT))
+                    .write_timeout(Some(TIMEOUT))
+                    .tcp_connect_timeout(Some(TIMEOUT)),
+            )?),
+            DatabaseType::PostgreSQL => todo!("PostgreSQL connections"),
+        })
+    }
+
+    pub fn query<T: FromRow>(&mut self, query: &str) -> Result<Vec<T>> {
+        Ok(match self {
+            SQLConnection::MySQL(conn) => conn.query(query)?,
+            SQLConnection::PostgreSQL => todo!("PostgreSQL query"),
+        })
+    }
+
+    pub fn query_first<T: FromRow>(&mut self, query: &str) -> Result<Option<T>> {
+        Ok(match self {
+            SQLConnection::MySQL(conn) => conn.query_first(query)?,
+            SQLConnection::PostgreSQL => todo!("PostgreSQL query_first"),
+        })
+    }
+
+    pub fn query_drop(&mut self, query: &str) -> Result<()> {
+        match self {
+            SQLConnection::MySQL(conn) => conn.query_drop(query)?,
+            SQLConnection::PostgreSQL => todo!("PostgreSQL query_drop"),
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This patch adds a new and optional configuration option, database_type, to the set of options available in the scheduler's config.  Valid values are "mysql" and "postgresql", and if the option is omitted, "mysql" as treated as the default.

Note that this patch does not yet introduce PostgreSQL support, but provides the initial restructuring of the scheduler.

Abstract usage of an SQL connection into a new module, sql_connection, and a new enum representing a connection, SQLConnection, which represents either a MySQL or a PostgreSQL connection.  Also replace all uses of mysql::Conn with the new SQLConnection enum, which acts as a thin wrapper.