### PR TITLE
Add readyset_database configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Configure `/etc/readyset_proxysql_scheduler.cnf` as follow:
 * `proxysql_port` - (Required) - ProxySQL admin port
 * `readyset_user` - (Required) - Readyset application user
 * `readyset_password` - (Required) - Readyset application password
+* `readyset_database` - (Optional) - Readyset application database
 * `source_hostgroup` - (Required) - Hostgroup running your Read workload
 * `readyset_hostgroup` - (Required) - Hostgroup where Readyset is configure
 * `warmup_time_s` - (Optional) - Time in seconds to mirror a query supported before redirecting the query to Readyset (Default `0` - no mirror)

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,7 @@ pub struct Config {
     pub proxysql_port: u16,
     pub readyset_user: String,
     pub readyset_password: String,
+    pub readyset_database: Option<String>,
     pub source_hostgroup: u16,
     pub readyset_hostgroup: u16,
     #[serde(default)]

--- a/src/proxysql.rs
+++ b/src/proxysql.rs
@@ -53,6 +53,7 @@ impl ProxySQL {
             config.proxysql_port,
             &config.proxysql_user,
             &config.proxysql_password,
+            None,
         ) {
             Ok(conn) => conn,
             Err(err) => panic!("Failed to create ProxySQL connection: {err}"),

--- a/src/readyset.rs
+++ b/src/readyset.rs
@@ -116,6 +116,7 @@ impl Readyset {
             port,
             &config.readyset_user,
             &config.readyset_password,
+            config.readyset_database.as_deref(),
         ) {
             Ok(conn) => conn,
             Err(err) => {


### PR DESCRIPTION
In order to connect to a Readyset instance via PostgreSQL, it may be required to specify the database name.  This patch adds an optional configuration for specifying the database when connecting to Readyset.